### PR TITLE
Use Git instead of find for the example in the documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,12 +94,12 @@ To show the options, run the following commands.
    $ files_to_compilation_database_cpp --help
 
 The simplest usage is to pipe a list of filenames to the program.  The
-following command shows the usage with UNIX ``find`` to generate the
-list of C and C++ source and header filenames.
+following command shows the usage with Git to generate the list of C
+and C++ source and header filenames.
 
 ::
 
-   $ find . \( -name \*.[ch]pp -o -name \*.[ch] \) | \
+   $ git ls-files *.[ch] *.[ch]pp | \
        files_to_compilation_database_py \
        --cflags="-std=c89" \
        --cxxflags="-std=c++11" \


### PR DESCRIPTION
This pull request documents the use of `git ls-files` to generate the list of files used to generate a compilation database.  This is faster and more portable than the UNIX `find` command.

See #7.